### PR TITLE
feat: add option for double precision in prediction mode

### DIFF
--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -41,6 +41,9 @@ const int SHARED_PARAMETER_SIZE = 5000;
 // use caching algorithm for fast helix length scores
 #define FAST_HELIX_LENGTHS                         1
 
+// use double precision for prediction 
+#define USE_DOUBLE_IN_PREDICT                      0
+
 //////////////////////////////////////////////////////////////////////
 // Options related to training mode configuration
 //////////////////////////////////////////////////////////////////////

--- a/src/Contrafold.cpp
+++ b/src/Contrafold.cpp
@@ -57,6 +57,13 @@ void RunPredictionFoldChangeMode(const Options &options, const std::vector<FileD
 // default parameters
 #include "Defaults.ipp"
 
+// precision for prediction
+#if USE_DOUBLE_IN_PREDICT
+typedef double pf_type;
+#else
+typedef float pf_type;
+#endif
+
 /////////////////////////////////////////////////////////////////
 // main()
 //
@@ -118,7 +125,7 @@ int main(int argc, char **argv)
     }
     else
     {
-        RunPredictionMode<float>(options, descriptions);
+        RunPredictionMode<pf_type>(options, descriptions);
     }
     
 #ifdef MULTI


### PR DESCRIPTION
## Summary
For longer sequences, pairing probability for a nucleotide can exceed 1 due to single-precision floating-point arithmetics. 

## Implementation Notes
Option `USE_DOUBLE_IN_PREDICT` was added to the configuration file `Config.hpp`. When set to `1`, the prediction routine will use double-precision arithmetics instead of single-precision.

## Testing
The behaviour was tested on a set of random sequences, and the results are shown in the following [report](https://github.com/domen13/LinearPartition/tree/eternafold_patch/tests). Using double-precision, no corrupted probabilities larger than 1 were observed.

## Related Issues
Resolves #2.
