### PR TITLE
chore: Updated patch files to not need whitespace fixing

### DIFF
--- a/LinearFold-E.patch
+++ b/LinearFold-E.patch
@@ -1,22 +1,24 @@
 diff --git a/Makefile b/Makefile
-index 2c10c80..2b5ffa7 100644
+index 2c10c80..ecfe992 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -6,16 +6,17 @@
  ################################
  
  CC=g++
--DEPS=src/LinearFoldEval.cpp src/LinearFold.h src/Utils/energy_parameter.h src/Utils/feature_weight.h src/Utils/intl11.h src/Utils/intl21.h src/Utils/intl22.h src/Utils/utility_v.h src/Utils/utility.h
+-DEPS=src/LinearFoldEval.cpp src/LinearFold.h src/Utils/energy_parameter.h src/Utils/feature_weight.h src/Utils/intl11.h src/Utils/intl21.h src/Utils/intl22.h src/Utils/utility_v.h src/Utils/utility.h 
 +DEPS=src/LinearFoldEval.cpp src/LinearFold.h src/Utils/energy_parameter.h src/Utils/feature_weight.h src/Utils/feature_weight_e.h src/Utils/intl11.h src/Utils/intl21.h src/Utils/intl22.h src/Utils/utility_v.h src/Utils/utility.h
  CFLAGS=-std=c++11 -O3
  .PHONY : clean linearfold
 -objects=bin/linearfold_v bin/linearfold_c
 +objects=bin/linearfold_v bin/linearfold_c bin/linearfold_e
  
- linearfold: src/LinearFold.cpp $(DEPS)
+-linearfold: src/LinearFold.cpp $(DEPS) 
++linearfold: src/LinearFold.cpp $(DEPS)
  		chmod +x linearfold draw_circular_plot
  		mkdir -p bin
- 		$(CC) src/LinearFold.cpp $(CFLAGS) -Dlv -Dis_cube_pruning -Dis_candidate_list -o bin/linearfold_v
+-		$(CC) src/LinearFold.cpp $(CFLAGS) -Dlv -Dis_cube_pruning -Dis_candidate_list -o bin/linearfold_v 
++		$(CC) src/LinearFold.cpp $(CFLAGS) -Dlv -Dis_cube_pruning -Dis_candidate_list -o bin/linearfold_v
  		$(CC) src/LinearFold.cpp $(CFLAGS) -Dis_cube_pruning -Dis_candidate_list -o bin/linearfold_c
 +		$(CC) src/LinearFold.cpp $(CFLAGS) -Dlpe -Dis_cube_pruning -Dis_candidate_list -o bin/linearfold_e
  
@@ -25,7 +27,7 @@ index 2c10c80..2b5ffa7 100644
 \ No newline at end of file
 diff --git a/src/Utils/feature_weight_e.h b/src/Utils/feature_weight_e.h
 new file mode 100644
-index 0000000..5bbb480
+index 0000000..2cf420b
 --- /dev/null
 +++ b/src/Utils/feature_weight_e.h
 @@ -0,0 +1,36 @@

--- a/LinearPartition-E.patch
+++ b/LinearPartition-E.patch
@@ -1,5 +1,5 @@
 diff --git a/Makefile b/Makefile
-index 49a7aca..a4c6e20 100755
+index 49a7aca..720f4bb 100755
 --- a/Makefile
 +++ b/Makefile
 @@ -6,16 +6,17 @@
@@ -13,10 +13,12 @@ index 49a7aca..a4c6e20 100755
 -objects=bin/linearpartition_v bin/linearpartition_c
 +objects=bin/linearpartition_v bin/linearpartition_c bin/linearpartition_e
  
- linearpartition: src/LinearPartition.cpp $(DEPS)
+-linearpartition: src/LinearPartition.cpp $(DEPS) 
++linearpartition: src/LinearPartition.cpp $(DEPS)
  		chmod +x linearpartition draw_bpp_plot draw_heatmap
  		mkdir -p bin
- 		$(CC) src/LinearPartition.cpp $(CFLAGS) -Dlpv -o bin/linearpartition_v
+-		$(CC) src/LinearPartition.cpp $(CFLAGS) -Dlpv -o bin/linearpartition_v 
++		$(CC) src/LinearPartition.cpp $(CFLAGS) -Dlpv -o bin/linearpartition_v
  		$(CC) src/LinearPartition.cpp $(CFLAGS) -o bin/linearpartition_c
 +		$(CC) src/LinearPartition.cpp $(CFLAGS) -Dlpe -o bin/linearpartition_e
  
@@ -25,7 +27,7 @@ index 49a7aca..a4c6e20 100755
 \ No newline at end of file
 diff --git a/src/Utils/feature_weight_e.h b/src/Utils/feature_weight_e.h
 new file mode 100644
-index 0000000..5bbb480
+index 0000000..2cf420b
 --- /dev/null
 +++ b/src/Utils/feature_weight_e.h
 @@ -0,0 +1,36 @@
@@ -67,7 +69,7 @@ index 0000000..5bbb480
 +#endif
 \ No newline at end of file
 diff --git a/src/Utils/utility.h b/src/Utils/utility.h
-index 0601a4d..a5866b1 100755
+index 0601a4d..5c96a39 100755
 --- a/src/Utils/utility.h
 +++ b/src/Utils/utility.h
 @@ -13,7 +13,11 @@

--- a/README_LinearFold-E_patch.md
+++ b/README_LinearFold-E_patch.md
@@ -29,7 +29,7 @@ git reset --hard ae6507f3053573decd2e4bdae60d5a96eac87783
 
 ```
 cd LinearFold
-git apply --whitespace=fix /PATH/TO/ETERNAFOLD/LinearFold-E.patch
+git apply /PATH/TO/ETERNAFOLD/LinearFold-E.patch
 make
 cd ..
 ```
@@ -38,7 +38,7 @@ cd ..
 
 ```
 cd LinearPartition
-git apply --whitespace=fix /PATH/TO/ETERNAFOLD/LinearPartition-E.patch
+git apply /PATH/TO/ETERNAFOLD/LinearPartition-E.patch
 make
 cd ..
 ```


### PR DESCRIPTION
I regenerated and tested the patch files for LinearFold and LinearPartition. I can confirm they now work without using `--whitespace=fix` and can also use `patch(1)`.

Closes: #3